### PR TITLE
ale-203 supress hmr warnings for framework files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,7 +35,24 @@ export default [
       // React Refresh rules
       'react-refresh/only-export-components': [
         'warn',
-        { allowConstantExport: true },
+        {
+          allowConstantExport: true,
+
+          // React router Framework takes care of these specific exports
+          allowExportNames: [
+            'loader',
+            'clientLoader',
+            'action',
+            'clientAction',
+            'ErrorBoundary',
+            'HydrateFallback',
+            'headers',
+            'handle',
+            'links',
+            'meta',
+            'shouldRevalidate',
+          ],
+        },
       ],
 
       // Override some rules to be less strict


### PR DESCRIPTION
Stops the linter from warning on exports related to fast refresh for react router specific framework exports as these shouldn't be a problem https://reactrouter.com/explanation/hot-module-replacement#supported-exports - other exports from files will still warn

<!-- greptile_comment -->

## Greptile Summary

This PR updates the ESLint configuration to suppress Hot Module Replacement (HMR) warnings for React Router v7 framework-specific exports. The change adds an `allowExportNames` array to the `react-refresh/only-export-components` rule, whitelisting official React Router exports like `loader`, `action`, `meta`, `ErrorBoundary`, etc.

• **Problem**: React Router v7's file-based routing requires specific named exports from route files, but the existing ESLint rule was flagging these as violations
• **Solution**: Configure the linter to recognize these framework exports as legitimate while maintaining warnings for other non-component exports
• **Integration**: This aligns the linting configuration with React Router v7's architecture and HMR best practices

## Important Files Changed

<details>
<summary>File Changes</summary>

| Filename | Score | Overview |
|----------|-------|-----------|
| eslint.config.js | 4/5 | Added `allowExportNames` configuration to whitelist React Router v7 framework exports |

</details>

## Manual Testing Recommendations

- [ ] Verify HMR warnings are suppressed for route files with `loader`, `action`, `meta`, etc. exports
- [ ] Confirm non-framework exports still trigger warnings appropriately  
- [ ] Test hot reload functionality works correctly with these exports
- [ ] Check that TypeScript compilation still passes with no new errors

## Automated Testing

- [ ] Add ESLint rule tests for each allowed export name
- [ ] Test that non-allowed exports still trigger warnings
- [ ] Integration tests for HMR behavior with framework exports

## Architecture and Design Review

• **Best Practices**: Follows React Router v7 documentation for HMR configuration
• **Code Quality**: Maintains strict linting while allowing necessary framework patterns
• **Documentation**: Clear comments explain the purpose with official documentation links
• **Scope**: Minimal, targeted change affecting only the specific rule needed

## Confidence score: 4/5

• This is a safe configuration change that aligns with React Router v7 best practices
• High confidence due to well-documented approach following official React Router guidance
• No files need additional attention - the change is straightforward and well-implemented

## Sequence Diagram
```mermaid
sequenceDiagram
    participant Developer
    participant VSCode/Editor
    participant ESLint
    participant ReactRouter

    Developer->>VSCode/Editor: Creates/edits React Router route file
    VSCode/Editor->>ESLint: Runs linting on file save
    ESLint->>ESLint: Checks react-refresh/only-export-components rule
    ESLint->>ESLint: Finds React Router framework exports (loader, action, etc.)
    ESLint->>ESLint: Checks allowExportNames configuration
    ESLint->>ESLint: Validates exports against allowed framework exports
    ESLint->>VSCode/Editor: Returns no warnings for framework exports
    VSCode/Editor->>Developer: Shows clean file with no HMR warnings
```

<!-- /greptile_comment -->