### PR TITLE
feat: use conform for client-side form validation

### DIFF
--- a/app/auth/_lib/signup-schema.test.ts
+++ b/app/auth/_lib/signup-schema.test.ts
@@ -1,0 +1,86 @@
+import { faker } from '@faker-js/faker'
+import * as v from 'valibot'
+import { expect, test, assert } from 'vitest'
+import { SignupSchema } from './signup-schema'
+
+function makeSignupPayload({
+  email = faker.internet.email(),
+  password = faker.internet.password({ length: 8 }),
+}: {
+  email?: string
+  password?: string
+} = {}) {
+  return {
+    email,
+    password,
+  }
+}
+
+test('valid data', async () => {
+  const payload = makeSignupPayload()
+  const result = v.safeParse(SignupSchema, payload)
+  expect(result).toEqual({
+    success: true,
+    output: payload,
+    issues: undefined,
+    typed: true,
+  })
+})
+
+test('missing email', async () => {
+  const payload = makeSignupPayload({ email: '' })
+  const result = v.safeParse(SignupSchema, payload)
+
+  assert(!result.success, 'Expected validation to fail')
+
+  const flattenedIssues = v.flatten<typeof SignupSchema>(result.issues)
+
+  expect(flattenedIssues).toEqual({
+    nested: {
+      email: ['Please enter an email address'],
+    },
+  })
+})
+
+test('missing password', async () => {
+  const payload = makeSignupPayload({ password: '' })
+  const result = v.safeParse(SignupSchema, payload)
+
+  assert(!result.success, 'Expected validation to fail')
+
+  const flattenedIssues = v.flatten<typeof SignupSchema>(result.issues)
+
+  expect(flattenedIssues).toEqual({
+    nested: {
+      password: ['Please enter a password'],
+    },
+  })
+})
+test('password too short', async () => {
+  const payload = makeSignupPayload({ password: 'short' })
+  const result = v.safeParse(SignupSchema, payload)
+
+  assert(!result.success, 'Expected validation to fail')
+
+  const flattenedIssues = v.flatten<typeof SignupSchema>(result.issues)
+
+  expect(flattenedIssues).toEqual({
+    nested: {
+      password: ['Password must be at least 8 characters long'],
+    },
+  })
+})
+test('invalid email', async () => {
+  const payload = makeSignupPayload({ email: 'invalid-email' })
+  const result = v.safeParse(SignupSchema, payload)
+
+  assert(!result.success, 'Expected validation to fail')
+
+  const flattenedIssues = v.flatten<typeof SignupSchema>(result.issues)
+
+  expect(flattenedIssues).toEqual({
+    nested: {
+      email: ['Please enter a valid email address'],
+    },
+  })
+})

--- a/app/auth/_lib/signup-schema.ts
+++ b/app/auth/_lib/signup-schema.ts
@@ -1,0 +1,32 @@
+import * as v from 'valibot'
+
+/**
+ * Transforms an empty string to undefined.
+ * This can be used to show different error messages for empty form fields compared with non-empty invalid fields
+ */
+const transformEmptyStringToUndefined = v.transform((value) => {
+  if (typeof value !== 'string') {
+    return value
+  }
+
+  if (value.trim() === '') {
+    return undefined
+  }
+
+  return value
+})
+
+export const SignupSchema = v.object({
+  email: v.pipe(
+    v.unknown(),
+    transformEmptyStringToUndefined,
+    v.string('Please enter an email address'),
+    v.email('Please enter a valid email address'),
+  ),
+  password: v.pipe(
+    v.unknown(),
+    transformEmptyStringToUndefined,
+    v.string('Please enter a password'),
+    v.minLength(8, 'Password must be at least 8 characters long'),
+  ),
+})

--- a/app/auth/signup.test.ts
+++ b/app/auth/signup.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from 'vitest'
+import { test, expect, assert } from 'vitest'
 import type { AppLoadContext } from 'react-router'
 import { faker } from '@faker-js/faker'
 import { action } from './signup'
@@ -46,80 +46,25 @@ function callSignupAction(request: Request) {
   })
 }
 
-test('valid form data', async () => {
+test('valid form data redirects to homepage', async () => {
   const payload = makeSignupPayload()
   const request = makeSignupRequest(payload)
 
   const result = await callSignupAction(request)
 
-  expect(result).toEqual({
-    result: 'success',
-    payload,
-    issues: null,
-  })
+  assert(result instanceof Response, 'Expected a response')
+  expect(result.status).toBe(302)
+  expect(result.headers.get('Location')).toBe('/')
 })
 
-test('missing email', async () => {
+test('invalid form data', async () => {
   const request = makeSignupRequest({ email: '' })
 
   const result = await callSignupAction(request)
 
   expect(result).toEqual(
     expect.objectContaining({
-      result: 'error',
-      issues: {
-        nested: {
-          email: ['Please enter an email address'],
-        },
-      },
-    }),
-  )
-})
-test('missing password', async () => {
-  const request = makeSignupRequest({ password: '' })
-
-  const result = await callSignupAction(request)
-
-  expect(result).toEqual(
-    expect.objectContaining({
-      result: 'error',
-      issues: {
-        nested: {
-          password: ['Please enter a password'],
-        },
-      },
-    }),
-  )
-})
-test('password too short', async () => {
-  const request = makeSignupRequest({ password: 'short' })
-
-  const result = await callSignupAction(request)
-
-  expect(result).toEqual(
-    expect.objectContaining({
-      result: 'error',
-      issues: {
-        nested: {
-          password: ['Password must be at least 8 characters long'],
-        },
-      },
-    }),
-  )
-})
-test('invalid email', async () => {
-  const request = makeSignupRequest({ email: 'invalid-email' })
-
-  const result = await callSignupAction(request)
-
-  expect(result).toEqual(
-    expect.objectContaining({
-      result: 'error',
-      issues: {
-        nested: {
-          email: ['Please enter a valid email address'],
-        },
-      },
+      status: 'error',
     }),
   )
 })

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "build:icons": "tsx ./build-icons.ts"
   },
   "dependencies": {
+    "@conform-to/react": "^1.8.2",
+    "@conform-to/valibot": "^1.8.2",
     "drizzle-orm": "0.44.3",
     "isbot": "5.1.28",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@conform-to/react':
+        specifier: ^1.8.2
+        version: 1.8.2(react@19.1.0)
+      '@conform-to/valibot':
+        specifier: ^1.8.2
+        version: 1.8.2(valibot@1.1.0(typescript@5.8.3))
       drizzle-orm:
         specifier: 0.44.3
         version: 0.44.3
@@ -357,6 +363,19 @@ packages:
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@conform-to/dom@1.8.2':
+    resolution: {integrity: sha512-5eDqI9366+23Fl/E5zxebuy2FCebJKpSrdE/c6PZQ5Ul59BYQ17pBmkLkvxAKjPXW+Qq77BJyjGjuklwmqN08A==}
+
+  '@conform-to/react@1.8.2':
+    resolution: {integrity: sha512-AJuHH4YY64o+VP3qsXd7bqlqCJYefTcEVj6mOiQr/m9iQV785gPtGE31jdmipvQ3ZHQE0Lp4e4th7kN/xo46qg==}
+    peerDependencies:
+      react: '>=18'
+
+  '@conform-to/valibot@1.8.2':
+    resolution: {integrity: sha512-IhR4scpou0CUL3Q5HedrepGn8oLCNbuhO53569ZCBFDL2lXorSv+k8JPKZ03JPYsjdQC79EkTDd24NA+jZiSrA==}
+    peerDependencies:
+      valibot: '>= 0.32.0'
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -4204,6 +4223,18 @@ snapshots:
 
   '@cloudflare/workerd-windows-64@1.20250712.0':
     optional: true
+
+  '@conform-to/dom@1.8.2': {}
+
+  '@conform-to/react@1.8.2(react@19.1.0)':
+    dependencies:
+      '@conform-to/dom': 1.8.2
+      react: 19.1.0
+
+  '@conform-to/valibot@1.8.2(valibot@1.1.0(typescript@5.8.3))':
+    dependencies:
+      '@conform-to/dom': 1.8.2
+      valibot: 1.1.0(typescript@5.8.3)
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:


### PR DESCRIPTION
Adds client-side form validation with conform.

To avoid testing too closely the internals of the conform reply I've extracted the signup schema to a new file and covered it with unit tests. The test for the action itself now just checks if it returns an error or a successful redirect

<!-- greptile_comment -->

## Greptile Summary

This PR introduces client-side form validation to the signup form using the Conform library integrated with the existing Valibot validation schema. The key architectural improvement is the extraction of the signup validation schema into a dedicated module (`app/auth/_lib/signup-schema.ts`), which enables better separation of concerns and comprehensive unit testing.

The changes transform the signup form from server-only validation to a progressive enhancement approach where validation occurs on both client-side (onBlur/onInput events) and server-side. The same Valibot schema is now shared between both validation contexts through Conform's `parseWithValibot` utility, ensuring consistency across the validation pipeline.

The extracted schema includes a custom transform function that intelligently handles empty strings by converting them to `undefined`, which allows for more specific error messaging ("Please enter an email address" vs "Please enter a valid email address"). This provides better UX by distinguishing between missing fields and invalid but present fields.

The refactoring maintains the existing React Router v7 action/loader architecture while adding modern form handling patterns. The action function is simplified by leveraging Conform's `SubmissionResult` type, and the component uses Conform's `useForm` hook for managing form state and validation timing.

## Important Files Changed

<details>
<summary>Files Modified</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `app/auth/_lib/signup-schema.ts` | 5/5 | New validation schema module with custom transform for empty string handling |
| `app/auth/_lib/signup-schema.test.ts` | 5/5 | Comprehensive unit tests covering all validation scenarios with factory helpers |
| `app/auth/signup.tsx` | 4/5 | Refactored to use Conform with client-side validation and simplified action function |
| `app/auth/signup.test.ts` | 4/5 | Updated tests to focus on action behavior rather than validation internals |
| `package.json` | 5/5 | Added Conform dependencies for React and Valibot integration |

</details>

## Manual Testing Recommendations

- [ ] Test form with valid email/password combination redirects to homepage
- [ ] Test empty email field shows "Please enter an email address"
- [ ] Test empty password field shows "Please enter a password"
- [ ] Test invalid email format shows "Please enter a valid email address"
- [ ] Test password under 8 characters shows length validation error
- [ ] Test client-side validation triggers on blur events
- [ ] Test real-time validation on input after initial blur
- [ ] Test form works without JavaScript (server-side fallback)
- [ ] Test accessibility with screen readers for error announcements

## Automated Testing

- [x] Unit tests for schema validation logic with comprehensive coverage
- [x] Integration tests for action function behavior
- [ ] Component rendering tests for different form states
- [ ] End-to-end tests for complete signup flow
- [ ] Accessibility tests for ARIA attributes and error associations
- [ ] Visual regression tests for error state UI
- [ ] Cross-browser compatibility tests for form validation

## Architecture and Design Review

**Excellent architectural decisions:**
- **Separation of concerns**: Schema extraction enables better testability and reusability
- **Progressive enhancement**: Form works without JavaScript while providing enhanced UX with it
- **Type safety**: Full TypeScript integration throughout validation pipeline
- **Modern patterns**: Follows React Router v7 best practices with proper action/loader architecture
- **Smart error handling**: Custom transform provides better UX messaging for empty vs invalid fields
- **Library choice**: Conform is well-maintained and integrates seamlessly with existing Valibot setup

**Minor considerations:**
- Bundle size increases by ~30KB but justified for UX improvement
- Missing loading states during form submission
- Could benefit from error boundary for unexpected validation failures

## Confidence score: 4/5

• This PR is very safe to merge with excellent architectural improvements and comprehensive testing
• Score reflects minor gaps in error handling completeness and missing integration tests, but core functionality is solid
• Files `app/auth/signup.tsx` and `app/auth/signup.test.ts` need brief review for error handling completeness

## Sequence Diagram
```mermaid
sequenceDiagram
    participant User
    participant SignupForm
    participant ConformValidation
    participant SignupSchema
    participant ServerAction
    participant Router

    User->>SignupForm: Fills out email and password
    User->>SignupForm: Triggers onBlur event
    SignupForm->>ConformValidation: onValidate with formData
    ConformValidation->>SignupSchema: parseWithValibot(formData)
    SignupSchema-->>ConformValidation: Validation result
    ConformValidation-->>SignupForm: Client-side validation feedback
    SignupForm-->>User: Show validation errors (if any)

    User->>SignupForm: Modifies input (onInput)
    SignupForm->>ConformValidation: shouldRevalidate
    ConformValidation->>SignupSchema: parseWithValibot(formData)
    SignupSchema-->>ConformValidation: Validation result
    ConformValidation-->>SignupForm: Updated validation feedback
    SignupForm-->>User: Show updated validation state

    User->>SignupForm: Submits form
    SignupForm->>ServerAction: POST request with formData
    ServerAction->>SignupSchema: parseWithValibot(formData)
    SignupSchema-->>ServerAction: Validation result

    alt Validation successful
        ServerAction->>Router: redirect('/')
        Router-->>User: Redirect to homepage
    else Validation failed
        ServerAction-->>SignupForm: Return submission.reply()
        SignupForm-->>User: Display server validation errors
    end
```

<!-- /greptile_comment -->