### PR TITLE
Ale 192 create user in database on signup

### DIFF
--- a/app/auth/_actions/signup-action.test.ts
+++ b/app/auth/_actions/signup-action.test.ts
@@ -1,7 +1,13 @@
-import { test, expect, assert } from 'vitest'
-import type { AppLoadContext } from 'react-router'
 import { faker } from '@faker-js/faker'
-import { action } from './signup'
+import { assert, expect, test, vi } from 'vitest'
+import { makeSignupAction } from './signup-action'
+
+const mockSaveUser = vi.fn()
+mockSaveUser.mockName('saveUser')
+
+const signupAction = makeSignupAction({
+  saveUser: mockSaveUser,
+})
 
 function makeSignupPayload({
   email = faker.internet.email(),
@@ -27,44 +33,27 @@ function makeSignupFormData({
   return formData
 }
 
-function makeSignupRequest(
-  payload: Partial<ReturnType<typeof makeSignupPayload>> = {},
-) {
-  const formData = makeSignupFormData(payload)
-  return new Request('http://app.com/signup', {
-    method: 'POST',
-    body: formData,
-  })
-}
-
-function callSignupAction(request: Request) {
-  return action({
-    request,
-    params: {},
-    // For now we don't care about the context in tests, in future we may need to mock it
-    context: {} as AppLoadContext,
-  })
-}
-
 test('valid form data redirects to homepage', async () => {
   const payload = makeSignupPayload()
-  const request = makeSignupRequest(payload)
+  const formData = makeSignupFormData(payload)
 
-  const result = await callSignupAction(request)
+  const result = await signupAction(formData)
 
   assert(result instanceof Response, 'Expected a response')
+  expect(mockSaveUser).toHaveBeenCalledWith(payload)
   expect(result.status).toBe(302)
   expect(result.headers.get('Location')).toBe('/')
 })
 
 test('invalid form data', async () => {
-  const request = makeSignupRequest({ email: '' })
+  const formData = makeSignupFormData({ email: '' })
 
-  const result = await callSignupAction(request)
+  const result = await signupAction(formData)
 
   expect(result).toEqual(
     expect.objectContaining({
       status: 'error',
     }),
   )
+  expect(mockSaveUser).not.toHaveBeenCalled()
 })

--- a/app/auth/_actions/signup-action.ts
+++ b/app/auth/_actions/signup-action.ts
@@ -7,7 +7,7 @@ import { SignupSchema, type SignupData } from '../_lib/signup-schema'
 export function makeSignupAction({
   saveUser,
 }: {
-  saveUser: (user: SignupData) => Promise<void>
+  saveUser: (user: SignupData) => Promise<{ id: number; email: string }>
 }) {
   return async function signupAction(
     formData: FormData,
@@ -20,13 +20,13 @@ export function makeSignupAction({
 
     try {
       await saveUser(submission.value)
+      // TODO: create a session for the user
+      return redirect('/')
     } catch (error) {
       console.error(error)
       return submission.reply({
         formErrors: ['Something went wrong. Please try again later.'],
       })
     }
-
-    return redirect('/')
   }
 }

--- a/app/auth/_actions/signup-action.ts
+++ b/app/auth/_actions/signup-action.ts
@@ -1,0 +1,32 @@
+import { redirect } from 'react-router'
+
+import { type SubmissionResult } from '@conform-to/react'
+import { parseWithValibot } from '@conform-to/valibot'
+import { SignupSchema, type SignupData } from '../_lib/signup-schema'
+
+export function makeSignupAction({
+  saveUser,
+}: {
+  saveUser: (user: SignupData) => Promise<void>
+}) {
+  return async function signupAction(
+    formData: FormData,
+  ): Promise<SubmissionResult | Response> {
+    const submission = parseWithValibot(formData, { schema: SignupSchema })
+
+    if (submission.status !== 'success') {
+      return submission.reply()
+    }
+
+    try {
+      await saveUser(submission.value)
+    } catch (error) {
+      console.error(error)
+      return submission.reply({
+        formErrors: ['Something went wrong. Please try again later.'],
+      })
+    }
+
+    return redirect('/')
+  }
+}

--- a/app/auth/_lib/signup-schema.ts
+++ b/app/auth/_lib/signup-schema.ts
@@ -30,3 +30,4 @@ export const SignupSchema = v.object({
     v.minLength(8, 'Password must be at least 8 characters long'),
   ),
 })
+export type SignupData = v.InferOutput<typeof SignupSchema>

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -52,6 +52,7 @@ export default function Signup() {
         onSubmit={form.onSubmit}
         className="flex flex-col gap-4"
         noValidate
+        aria-describedby={form.errors ? form.errorId : undefined}
       >
         <Field>
           <Label htmlFor={fields.email.id}>Email Address</Label>
@@ -91,12 +92,15 @@ export default function Signup() {
             id={fields.password.errorId}
           />
         </Field>
-        <button
-          type="submit"
-          className="cursor-pointer rounded-lg bg-blue-500 px-4 py-3 text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-gray-400"
-        >
-          Sign Up
-        </button>
+        <div className="flex flex-col gap-2">
+          <button
+            type="submit"
+            className="cursor-pointer rounded-lg bg-blue-500 px-4 py-3 text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-gray-400"
+          >
+            Sign Up
+          </button>
+          <FieldError errors={form.errors} id={form.errorId} />
+        </div>
       </Form>
       <div className="h-px w-full bg-gray-200" />
       <p className="text-center text-sm text-gray-600">

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -10,17 +10,19 @@ import { FieldDescription } from '~/components/field-description'
 import { FieldError } from '~/components/field-error'
 import { Input } from '~/components/input'
 import { Label } from '~/components/label'
-
-const signupAction = makeSignupAction({
-  saveUser: async () => {
-    // TODO: save user to database
-  },
-})
+import { createUser } from '~/data-layer/user'
 
 export async function action({
   request,
+  context,
 }: Route.ActionArgs): Promise<SubmissionResult | Response> {
   const formData = await request.formData()
+
+  const signupAction = makeSignupAction({
+    saveUser: async (userDto) => {
+      return createUser(context.db, userDto)
+    },
+  })
 
   return signupAction(formData)
 }

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -1,26 +1,28 @@
-import { Form, Link, redirect, useActionData } from 'react-router'
+import { Form, Link, useActionData } from 'react-router'
 
-import { parseWithValibot } from '@conform-to/valibot'
 import { useForm, type SubmissionResult } from '@conform-to/react'
+import { parseWithValibot } from '@conform-to/valibot'
 import type { Route } from './+types/signup'
+import { makeSignupAction } from './_actions/signup-action'
 import { SignupSchema } from './_lib/signup-schema'
-import { Input } from '~/components/input'
-import { Label } from '~/components/label'
+import { Field } from '~/components/field'
 import { FieldDescription } from '~/components/field-description'
 import { FieldError } from '~/components/field-error'
-import { Field } from '~/components/field'
+import { Input } from '~/components/input'
+import { Label } from '~/components/label'
+
+const signupAction = makeSignupAction({
+  saveUser: async () => {
+    // TODO: save user to database
+  },
+})
 
 export async function action({
   request,
 }: Route.ActionArgs): Promise<SubmissionResult | Response> {
   const formData = await request.formData()
-  const submission = parseWithValibot(formData, { schema: SignupSchema })
 
-  if (submission.status !== 'success') {
-    return submission.reply()
-  }
-
-  return redirect('/')
+  return signupAction(formData)
 }
 
 export default function Signup() {

--- a/app/data-layer/user.ts
+++ b/app/data-layer/user.ts
@@ -1,0 +1,142 @@
+import { type AppLoadContext } from 'react-router'
+// import { eq } from 'drizzle-orm'
+import { users } from '~/database/schema'
+
+type Database = AppLoadContext['db']
+
+/**  Web Crypto API password hashing using PBKDF2 */
+async function hashPassword(password: string): Promise<string> {
+  // Generate a random salt
+  const salt = crypto.getRandomValues(new Uint8Array(16))
+
+  // Convert password to ArrayBuffer
+  const encoder = new TextEncoder()
+  const passwordBuffer = encoder.encode(password)
+
+  // Import password as key
+  const passwordKey = await crypto.subtle.importKey(
+    'raw',
+    passwordBuffer,
+    { name: 'PBKDF2' },
+    false,
+    ['deriveBits'],
+  )
+
+  // Derive key using PBKDF2
+  const derivedBits = await crypto.subtle.deriveBits(
+    {
+      name: 'PBKDF2',
+      salt: salt,
+      iterations: 100000, // High iteration count for security
+      hash: 'SHA-256',
+    },
+    passwordKey,
+    256, // 32 bytes = 256 bits
+  )
+
+  // Combine salt and hash
+  const hashArray = new Uint8Array(derivedBits)
+  const combined = new Uint8Array(salt.length + hashArray.length)
+  combined.set(salt)
+  combined.set(hashArray, salt.length)
+
+  // Convert to base64 string
+  return btoa(String.fromCharCode(...combined))
+}
+
+// Verify password against stored hash - we'll use this later
+// async function verifyPassword(
+//   password: string,
+//   storedHash: string,
+// ): Promise<boolean> {
+//   try {
+//     // Decode stored hash
+//     const combined = new Uint8Array(
+//       atob(storedHash)
+//         .split('')
+//         .map((char) => char.charCodeAt(0)),
+//     )
+
+//     // Extract salt and hash
+//     const salt = combined.slice(0, 16)
+//     const storedHashArray = combined.slice(16)
+
+//     // Convert password to ArrayBuffer
+//     const encoder = new TextEncoder()
+//     const passwordBuffer = encoder.encode(password)
+
+//     // Import password as key
+//     const passwordKey = await crypto.subtle.importKey(
+//       'raw',
+//       passwordBuffer,
+//       { name: 'PBKDF2' },
+//       false,
+//       ['deriveBits'],
+//     )
+
+//     // Derive key using same parameters
+//     const derivedBits = await crypto.subtle.deriveBits(
+//       {
+//         name: 'PBKDF2',
+//         salt: salt,
+//         iterations: 100000,
+//         hash: 'SHA-256',
+//       },
+//       passwordKey,
+//       256,
+//     )
+
+//     // Compare hashes
+//     const hashArray = new Uint8Array(derivedBits)
+//     return (
+//       hashArray.length === storedHashArray.length &&
+//       hashArray.every((value, index) => value === storedHashArray[index])
+//     )
+//   } catch {
+//     return false
+//   }
+// }
+
+export async function createUser(
+  db: Database,
+  userDto: { email: string; password: string },
+) {
+  const passwordHash = await hashPassword(userDto.password)
+  const [user] = await db
+    .insert(users)
+    .values({
+      email: userDto.email,
+      passwordHash,
+    })
+    .returning({ id: users.id, email: users.email })
+
+  return user
+}
+
+// We'll use this later
+// export async function verifyUserPassword(
+//   db: Database,
+//   email: string,
+//   password: string,
+// ): Promise<{ id: number; email: string } | null> {
+//   const [user] = await db
+//     .select({
+//       id: users.id,
+//       email: users.email,
+//       passwordHash: users.passwordHash,
+//     })
+//     .from(users)
+//     .where(eq(users.email, email))
+//     .limit(1)
+
+//   if (!user) {
+//     return null
+//   }
+
+//   const isValid = await verifyPassword(password, user.passwordHash)
+//   if (!isValid) {
+//     return null
+//   }
+
+//   return { id: user.id, email: user.email }
+// }

--- a/database/schema.ts
+++ b/database/schema.ts
@@ -5,3 +5,9 @@ export const guestBook = sqliteTable('guestBook', {
   name: text().notNull(),
   email: text().notNull().unique(),
 })
+
+export const users = sqliteTable('users', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  email: text().notNull().unique(),
+  passwordHash: text().notNull(),
+})

--- a/drizzle/0001_known_shape.sql
+++ b/drizzle/0001_known_shape.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`email` text NOT NULL,
+	`passwordHash` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,96 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "3f081506-675c-4b28-83e5-5aca0c49721f",
+  "prevId": "008ee181-36ed-4cc3-b593-481f13e2254a",
+  "tables": {
+    "guestBook": {
+      "name": "guestBook",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guestBook_email_unique": {
+          "name": "guestBook_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1732083994982,
       "tag": "0000_outstanding_trauma",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1753727260030,
+      "tag": "0001_known_shape",
+      "breakpoints": true
     }
   ]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -46,6 +46,7 @@ export default defineConfig({
           include: ['app/**/*.test.ts'],
           name: 'unit',
           environment: 'node',
+          clearMocks: true,
         },
       },
     ],


### PR DESCRIPTION
Save the user to the database on sign up. Creating a session and logging them in will come in a future PR. As will an end-to-end test to properly check the integration of the flow.
Adds form level error for if something goes wrong saving the user
Known limitation: will give unexpected error if user signs up with a pre-existing email address, will fix in follow up