### PR TITLE
feat: create a stack component

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
   "singleQuote": true,
-  "plugins": ["prettier-plugin-tailwindcss"]
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindFunctions": ["tv"]
 }

--- a/app/auth/layout.tsx
+++ b/app/auth/layout.tsx
@@ -1,13 +1,17 @@
 import { Outlet } from 'react-router'
 import logo from '../assets/images/logo.svg'
+import { Stack } from '~/components/stack'
+
 export default function AuthLayout() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gray-100 p-4">
-      <main className="flex max-w-130 basis-full flex-col gap-4 rounded-xl bg-white px-4 py-12 shadow-lg md:px-8 lg:max-w-135 lg:px-12">
-        <div className="flex justify-center pb-2">
-          <img src={logo} alt="Notes" />
-        </div>
-        <Outlet />
+      <main className="max-w-130 basis-full rounded-xl bg-white px-4 py-12 shadow-lg md:px-8 lg:max-w-135 lg:px-12">
+        <Stack gap="4">
+          <div className="flex justify-center pb-2">
+            <img src={logo} alt="Notes" />
+          </div>
+          <Outlet />
+        </Stack>
       </main>
     </div>
   )

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -11,6 +11,7 @@ import { FieldError } from '~/components/field-error'
 import { Input } from '~/components/input'
 import { Label } from '~/components/label'
 import { createUser } from '~/data-layer/user'
+import { Stack } from '~/components/stack'
 
 export async function action({
   request,
@@ -40,14 +41,14 @@ export default function Signup() {
 
   return (
     <>
-      <div className="flex flex-col items-center gap-2 text-center">
+      <Stack align="center" gap="2" className="text-center">
         <h1 className="text-2xl font-bold text-gray-950">
           Create Your Account
         </h1>
         <p className="text-sm text-gray-600">
           Sign up to start organizing your notes and boost your productivity.
         </p>
-      </div>
+      </Stack>
       <Form
         id={form.id}
         method="post"
@@ -94,7 +95,7 @@ export default function Signup() {
             id={fields.password.errorId}
           />
         </Field>
-        <div className="flex flex-col gap-2">
+        <Stack gap="2">
           <button
             type="submit"
             className="cursor-pointer rounded-lg bg-blue-500 px-4 py-3 text-white hover:bg-blue-700 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-gray-400"
@@ -102,7 +103,7 @@ export default function Signup() {
             Sign Up
           </button>
           <FieldError errors={form.errors} id={form.errorId} />
-        </div>
+        </Stack>
       </Form>
       <div className="h-px w-full bg-gray-200" />
       <p className="text-center text-sm text-gray-600">

--- a/app/components/field.tsx
+++ b/app/components/field.tsx
@@ -1,12 +1,13 @@
 import type { ComponentProps } from 'react'
+import { Stack } from './stack'
 
 export function Field({
   children,
   ...props
 }: Omit<ComponentProps<'div'>, 'className'>) {
   return (
-    <div {...props} className="group flex flex-col gap-2.5">
+    <Stack {...props} gap="1.5" className="group">
       {children}
-    </div>
+    </Stack>
   )
 }

--- a/app/components/stack.stories.tsx
+++ b/app/components/stack.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { Stack } from './stack'
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: 'Stack',
+  component: Stack,
+  args: {
+    children: (
+      <>
+        <div>Item 1</div>
+        <div>Item 2</div>
+        <div>Item 3</div>
+      </>
+    ),
+    gap: '4',
+    align: 'stretch',
+  },
+  argTypes: {
+    gap: {
+      control: 'select',
+      options: ['1.5', '2', '4'],
+    },
+    align: {
+      control: 'select',
+      options: ['start', 'center', 'end', 'stretch'],
+    },
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof Stack>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}

--- a/app/components/stack.tsx
+++ b/app/components/stack.tsx
@@ -1,0 +1,35 @@
+import type { ComponentProps } from 'react'
+import { tv, type VariantProps } from 'tailwind-variants'
+
+type SetRequired<T, K extends keyof T> = T & Required<Pick<T, K>>
+
+const stackStyles = tv({
+  base: 'flex flex-col',
+  variants: {
+    gap: {
+      '1.5': 'gap-1.5',
+      '2': 'gap-2',
+      '4': 'gap-4',
+    },
+    align: {
+      start: 'items-start',
+      center: 'items-center',
+      end: 'items-end',
+      stretch: 'items-stretch',
+    },
+  },
+  defaultVariants: {
+    align: 'stretch',
+  },
+})
+
+type StackVariants = SetRequired<VariantProps<typeof stackStyles>, 'gap'>
+
+export function Stack({
+  gap,
+  align,
+  className,
+  ...props
+}: ComponentProps<'div'> & StackVariants) {
+  return <div {...props} className={stackStyles({ gap, align, className })} />
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-router": "7.7.1",
+    "tailwind-merge": "^3.3.1",
+    "tailwind-variants": "^2.0.1",
     "valibot": "1.1.0"
   },
   "devDependencies": {
@@ -68,6 +70,7 @@
     "storybook-addon-remix-react-router": "5.0.0",
     "tailwindcss": "4.1.11",
     "tsx": "4.20.3",
+    "type-fest": "^4.41.0",
     "typescript": "5.8.3",
     "vite": "7.0.6",
     "vite-tsconfig-paths": "5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,12 @@ importers:
       react-router:
         specifier: 7.7.1
         version: 7.7.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.3.1
+      tailwind-variants:
+        specifier: ^2.0.1
+        version: 2.0.1(tailwind-merge@3.3.1)(tailwindcss@4.1.11)
       valibot:
         specifier: 1.1.0
         version: 1.1.0(typescript@5.8.3)
@@ -135,6 +141,9 @@ importers:
       tsx:
         specifier: 4.20.3
         version: 4.20.3
+      type-fest:
+        specifier: ^4.41.0
+        version: 4.41.0
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -3457,6 +3466,19 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  tailwind-merge@3.3.1:
+    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+
+  tailwind-variants@2.0.1:
+    resolution: {integrity: sha512-1wt8c4PWO3jbZcKGBrjIV8cehWarREw1C2os0k8Mcq0nof/CbafNhUUjb0LRWiiRfAvDK6v1deswtHLsygKglw==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
+
   tailwindcss@4.1.11:
     resolution: {integrity: sha512-2E9TBm6MDD/xKYe+dvJZAmg3yxIEDNRc0jwlNyDg/4Fil2QcSLjFKGVff0lAf1jjeaArlG/M75Ey/EYr/OJtBA==}
 
@@ -3543,6 +3565,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -7093,6 +7119,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  tailwind-merge@3.3.1: {}
+
+  tailwind-variants@2.0.1(tailwind-merge@3.3.1)(tailwindcss@4.1.11):
+    dependencies:
+      tailwindcss: 4.1.11
+    optionalDependencies:
+      tailwind-merge: 3.3.1
+
   tailwindcss@4.1.11: {}
 
   tapable@2.2.2: {}
@@ -7170,6 +7204,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   typed-array-buffer@1.0.3:
     dependencies:


### PR DESCRIPTION
Extracts a common `Stack` ui component. This is used in many places and should ensure a consistent spacing in the UI, and be easier to read than custom tailwind class names everywhere.
Also fixes a bug where the field was using an incorrect spacing (it should've been 6px not 10)