### PR TITLE
Ale 214 create password field

### DIFF
--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -10,6 +10,7 @@ import { FieldError } from '~/components/field-error'
 import { Input } from '~/components/input'
 import { Label } from '~/components/label'
 import { UserRepository, UserService } from '~/features/user/user-service'
+import { PasswordInput } from '~/components/password-input'
 
 export async function action({ request, context }: Route.ActionArgs) {
   const loginAction = makeLoginAction({
@@ -52,9 +53,11 @@ export default function Login() {
         </Field>
         <Field>
           <Label htmlFor={fields.password.id}>Password</Label>
-          <Input
+          <PasswordInput
             {...getInputProps(fields.password, {
-              type: 'password',
+              // We have to do this because **we** control the type of the input in the PasswordInput component
+              // and we can't let Conform try to control it
+              type: undefined as unknown as 'text',
             })}
             autoComplete="current-password"
           />

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -17,6 +17,7 @@ import { Input } from '~/components/input'
 import { Label } from '~/components/label'
 import { Stack } from '~/components/stack'
 import { UserRepository, UserService } from '~/features/user/user-service'
+import { PasswordInput } from '~/components/password-input'
 
 export async function action({
   request,
@@ -68,9 +69,11 @@ export default function Signup() {
         </Field>
         <Field>
           <Label htmlFor={fields.password.id}>Password</Label>
-          <Input
+          <PasswordInput
             {...getInputProps(fields.password, {
-              type: 'password',
+              // We have to do this because **we** control the type of the input in the PasswordInput component
+              // and we can't let Conform try to control it
+              type: undefined as unknown as 'text',
               // We only want to pass an additional description if the field doesn't have an error
               ariaDescribedBy: fields.password.errors
                 ? undefined

--- a/app/components/input.stories.tsx
+++ b/app/components/input.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { userEvent, within } from 'storybook/test'
+import { expect, fn, userEvent, within } from 'storybook/test'
 
 import { Input, InputAdornmentButton, InputAdornmentIcon } from './input'
 
@@ -54,10 +54,22 @@ export const WithEndAdornment: Story = {
   },
 }
 
+const mockClickHandler = fn()
+mockClickHandler.mockName('mockClickHandler')
+
 export const WithEndAdornmentButton: Story = {
   args: {
     endAdornment: (
-      <InputAdornmentButton iconName="icon-search" aria-label="Search" />
+      <InputAdornmentButton
+        iconName="icon-search"
+        aria-label="Search"
+        onClick={mockClickHandler}
+      />
     ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole('button', { name: 'Search' }))
+    await expect(mockClickHandler).toHaveBeenCalledOnce()
   },
 }

--- a/app/components/input.stories.tsx
+++ b/app/components/input.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
 import { userEvent, within } from 'storybook/test'
 
-import { Input, InputAdornmentIcon } from './input'
+import { Input, InputAdornmentButton, InputAdornmentIcon } from './input'
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta = {
@@ -51,5 +51,13 @@ export const WithStartAdornment: Story = {
 export const WithEndAdornment: Story = {
   args: {
     endAdornment: <InputAdornmentIcon name="icon-search" />,
+  },
+}
+
+export const WithEndAdornmentButton: Story = {
+  args: {
+    endAdornment: (
+      <InputAdornmentButton iconName="icon-search" aria-label="Search" />
+    ),
   },
 }

--- a/app/components/input.tsx
+++ b/app/components/input.tsx
@@ -1,6 +1,7 @@
 import { type ComponentProps, type ReactNode } from 'react'
 import { tv } from 'tailwind-variants'
 import { Icon } from './icon'
+import type { IconName } from './icon/names'
 
 const inputStyles = tv({
   slots: {
@@ -8,8 +9,13 @@ const inputStyles = tv({
     input:
       'col-span-full row-start-1 rounded-lg border border-gray-300 px-4 py-3 invalid:border-red-500 hover:bg-gray-50 focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 aria-invalid:border-red-500',
     adornmentIcon: 'size-5 text-gray-500',
-    startAdornment: 'col-start-1 row-start-1 self-center pl-4',
-    endAdornment: 'col-start-3 row-start-1 self-center pr-4',
+    startAdornment:
+      'pointer-events-none col-start-1 row-start-1 self-center pl-4',
+    endAdornment:
+      'pointer-events-none col-start-3 row-start-1 self-center pr-4',
+    // Includes a 48x48px click target pseudo-element for coarse pointer users
+    adornmentButton:
+      'pointer-events-auto relative block rounded not-pointer-fine:after:absolute not-pointer-fine:after:top-1/2 not-pointer-fine:after:left-1/2 not-pointer-fine:after:size-12 not-pointer-fine:after:-translate-x-1/2 not-pointer-fine:after:-translate-y-1/2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500',
   },
   variants: {
     hasStartAdornment: {
@@ -59,7 +65,24 @@ export function Input({
   )
 }
 
-export function InputAdornmentIcon(props: ComponentProps<typeof Icon>) {
+export function InputAdornmentIcon(
+  props: Omit<ComponentProps<typeof Icon>, 'className'>,
+) {
   const { adornmentIcon } = inputStyles()
   return <Icon {...props} className={adornmentIcon()} />
+}
+
+export function InputAdornmentButton({
+  iconName,
+  'aria-label': ariaLabel,
+}: {
+  iconName: IconName
+  'aria-label': string
+}) {
+  const { adornmentButton } = inputStyles()
+  return (
+    <button aria-label={ariaLabel} className={adornmentButton()}>
+      <InputAdornmentIcon name={iconName} />
+    </button>
+  )
 }

--- a/app/components/input.tsx
+++ b/app/components/input.tsx
@@ -74,14 +74,15 @@ export function InputAdornmentIcon(
 
 export function InputAdornmentButton({
   iconName,
-  'aria-label': ariaLabel,
+  ...buttonProps
 }: {
   iconName: IconName
-  'aria-label': string
-}) {
+} & Omit<ComponentProps<'button'>, 'aria-label' | 'className'> & {
+    'aria-label': string
+  }) {
   const { adornmentButton } = inputStyles()
   return (
-    <button aria-label={ariaLabel} className={adornmentButton()}>
+    <button {...buttonProps} className={adornmentButton()}>
       <InputAdornmentIcon name={iconName} />
     </button>
   )

--- a/app/components/input.tsx
+++ b/app/components/input.tsx
@@ -77,12 +77,12 @@ export function InputAdornmentButton({
   ...buttonProps
 }: {
   iconName: IconName
-} & Omit<ComponentProps<'button'>, 'aria-label' | 'className'> & {
+} & Omit<ComponentProps<'button'>, 'aria-label' | 'className' | 'type'> & {
     'aria-label': string
   }) {
   const { adornmentButton } = inputStyles()
   return (
-    <button {...buttonProps} className={adornmentButton()}>
+    <button {...buttonProps} className={adornmentButton()} type="button">
       <InputAdornmentIcon name={iconName} />
     </button>
   )

--- a/app/components/input.tsx
+++ b/app/components/input.tsx
@@ -15,7 +15,7 @@ const inputStyles = tv({
       'pointer-events-none col-start-3 row-start-1 self-center pr-4',
     // Includes a 48x48px click target pseudo-element for coarse pointer users
     adornmentButton:
-      'pointer-events-auto relative block rounded not-pointer-fine:after:absolute not-pointer-fine:after:top-1/2 not-pointer-fine:after:left-1/2 not-pointer-fine:after:size-12 not-pointer-fine:after:-translate-x-1/2 not-pointer-fine:after:-translate-y-1/2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500',
+      'pointer-events-auto relative block cursor-pointer rounded not-pointer-fine:after:absolute not-pointer-fine:after:top-1/2 not-pointer-fine:after:left-1/2 not-pointer-fine:after:size-12 not-pointer-fine:after:-translate-x-1/2 not-pointer-fine:after:-translate-y-1/2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500',
   },
   variants: {
     hasStartAdornment: {

--- a/app/components/password-input.stories.tsx
+++ b/app/components/password-input.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+
+import { userEvent, within, expect } from 'storybook/test'
+import { PasswordInput as PasswordInputComponent } from './password-input'
+
+const meta = {
+  title: 'PasswordInput',
+  component: PasswordInputComponent,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof PasswordInputComponent>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const ShowPassword: Story = {
+  args: {
+    placeholder: 'Enter your password',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByPlaceholderText('Enter your password')
+    await userEvent.type(input, 'my-password')
+    await userEvent.click(canvas.getByRole('button', { name: 'Show password' }))
+    await expect(input).toHaveAttribute('type', 'text')
+  },
+}
+
+export const HidePassword: Story = {
+  args: {
+    placeholder: 'Enter your password',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const input = canvas.getByPlaceholderText('Enter your password')
+    await userEvent.type(input, 'my-password')
+    await userEvent.click(canvas.getByRole('button', { name: 'Show password' }))
+    await userEvent.click(canvas.getByRole('button', { name: 'Hide password' }))
+    await expect(input).toHaveAttribute('type', 'password')
+  },
+}

--- a/app/components/password-input.tsx
+++ b/app/components/password-input.tsx
@@ -1,0 +1,29 @@
+import { type ComponentProps, useState } from 'react'
+import { Input, InputAdornmentButton } from './input'
+
+export function PasswordInput(props: Omit<ComponentProps<'input'>, 'type'>) {
+  const [showPassword, setShowPassword] = useState(false)
+  const toggleShowPassword = () => setShowPassword((show) => !show)
+
+  return (
+    <Input
+      type={showPassword ? 'text' : 'password'}
+      {...props}
+      endAdornment={
+        showPassword ? (
+          <InputAdornmentButton
+            iconName="icon-hide-password"
+            aria-label="Hide password"
+            onClick={toggleShowPassword}
+          />
+        ) : (
+          <InputAdornmentButton
+            iconName="icon-show-password"
+            aria-label="Show password"
+            onClick={toggleShowPassword}
+          />
+        )
+      }
+    />
+  )
+}

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -77,6 +77,7 @@ const Button: React.FC<ButtonProps> = ({ children, onClick, disabled }) => {
 - Use `as const` for literal type arrays
 - Prefer inferring return types over explicit return types except in situations where typescript cannot correctly infer the return type
 - Prefer object function arguments over positional function arguments
+- Type casting and type assertions should be avoided. If they are necessary, they must be commented with a justification.
 
 ```tsx
 // ✅ Good


### PR DESCRIPTION
Creates a PasswordInput field with a show/hide password button. Uses that component in the signup and login forms

<!-- greptile_comment -->

## Greptile Summary

This PR creates a new `PasswordInput` component with show/hide password functionality and integrates it into the authentication forms. The implementation includes:

• **New PasswordInput component** - Wraps the existing Input component with a toggle button to show/hide password text
• **Icon integration** - Adds new eye/eye-off icons and updates the icon system  
• **Form integration** - Updates login and signup forms to use the new PasswordInput component
• **Storybook stories** - Provides component documentation and testing scenarios
• **Style guide update** - Adds TypeScript rule requiring justification comments for type assertions
• **Input component enhancement** - Adds `cursor-pointer` class to adornment buttons for better UX

The component follows established patterns using function declarations, inline prop types, and Tailwind variants. It leverages the existing component system (Input, Icon, Field) for consistency and reusability.

## Important Files Changed

<details>
<summary>Files Changed</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| app/components/password-input.tsx | 4/5 | New PasswordInput component with show/hide toggle functionality |
| app/components/password-input.stories.tsx | 4/5 | Storybook stories for PasswordInput component documentation |
| app/components/input.tsx | 5/5 | Added cursor-pointer class to adornment buttons for better UX |
| app/components/icon/names.ts | 5/5 | Added eye and eye-off icon names to the icon system |
| app/auth/login.tsx | 4/5 | Updated login form to use new PasswordInput component |
| app/auth/signup.tsx | 4/5 | Updated signup form to use new PasswordInput component |
| build-icons.ts | 5/5 | Added eye and eye-off icons to the build script |
| svg-icons/eye-off.svg | 5/5 | New SVG icon for hiding password |
| svg-icons/eye.svg | 5/5 | New SVG icon for showing password |
| docs/style-guide.md | 5/5 | Added TypeScript rule requiring justification comments for type assertions |

</details>

## Manual Testing Recommendations

- [ ] Test password visibility toggle functionality in both login and signup forms
- [ ] Verify password input maintains focus when toggling visibility
- [ ] Test keyboard navigation to and from the toggle button
- [ ] Confirm screen reader announces button state changes appropriately
- [ ] Test form submission with both visible and hidden password states
- [ ] Verify toggle button styling and hover states work correctly
- [ ] Test password manager compatibility with the new component
- [ ] Verify cursor changes to pointer when hovering over input adornment buttons

## Automated Testing

- [ ] Add unit tests for PasswordInput component toggle functionality
- [ ] Add tests for proper aria-label updates when button state changes
- [ ] Test that password input type changes correctly between 'password' and 'text'
- [ ] Add E2E tests for login/signup flows using the new password component
- [ ] Test form validation continues to work with the new component
- [ ] Add accessibility tests for keyboard navigation and screen reader support
- [ ] Add visual regression tests for button hover states
- [ ] Consider adding interaction tests with Storybook play functions

## Architecture and Design Review

✅ **Component Design**: Well-structured component following established patterns with proper prop typing and composition
✅ **Accessibility**: Includes proper ARIA labels and semantic button usage for screen readers
✅ **Icon System**: Properly extends existing icon infrastructure with new eye icons
✅ **Reusability**: Component accepts all Input props via spread operator, maintaining flexibility
✅ **Style Guide Compliance**: Uses function declarations, inline prop types, and follows naming conventions
✅ **UX Enhancement**: Input component improvements provide better visual feedback for interactive elements
⚠️ **Testing Gap**: Component stories lack interactive `play` functions for automated interaction testing
⚠️ **Type Safety**: Uses `as` type assertion without justification comment (violates new style guide rule)

## Confidence score: 4/5

- This PR is generally safe to merge with minor concerns that should be addressed
- Score reflects solid implementation with good patterns but has accessibility and testing considerations that need attention
- Pay close attention to the PasswordInput component for type assertion usage and interactive testing coverage

### Context used:
**Style Guide -** General coding conventions to follow ([link](https://app.greptile.com/review/custom-context?memory=f8595ea5-226d-4583-b2c5-07edfb098862))

<!-- /greptile_comment -->