### PR TITLE
feat: add modified gap override for stack

### DIFF
--- a/app/components/stack.stories.tsx
+++ b/app/components/stack.stories.tsx
@@ -34,3 +34,10 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
+
+export const ResponsiveGaps: Story = {
+  args: {
+    gap: '2',
+    modifiedGaps: ['md:gap-4', 'lg:gap-12'],
+  },
+}

--- a/app/components/stack.tsx
+++ b/app/components/stack.tsx
@@ -25,11 +25,33 @@ const stackStyles = tv({
 
 type StackVariants = SetRequired<VariantProps<typeof stackStyles>, 'gap'>
 
+type Gap = `gap-${number}`
+type ModifiedGap = `${string}:${Gap}`
+type ModifiedGaps = Array<ModifiedGap>
+
 export function Stack({
   gap,
   align,
   className,
+  modifiedGaps,
   ...props
-}: ComponentProps<'div'> & StackVariants) {
-  return <div {...props} className={stackStyles({ gap, align, className })} />
+}: ComponentProps<'div'> &
+  StackVariants & {
+    /**
+     * Use this to modify the gap under certain conditions. E.g. to increase the gap size on larger screens.
+     *
+     * @example <Flex gap="gap-3" modifiedGaps={['md:gap-4', 'lg:gap-5']} />
+     */
+    modifiedGaps?: ModifiedGaps
+  }) {
+  return (
+    <div
+      {...props}
+      className={stackStyles({
+        gap,
+        align,
+        className: [modifiedGaps, className],
+      })}
+    />
+  )
 }


### PR DESCRIPTION
Adds a `modifiedGaps` prop to the `<Stack>` component. This enables consumers to create responsive stacks that have gaps that get bigger based on a media query, or container queries.

I don't love that there are now two props for gap related concerns. Maybe it would be better to make the gap prop accept a full tailwind gap string, or an array of them, and everything would be encapsulated in the same prop. I'd rather have it accept a string of gap related classnames, but I can't figure out a way to make typescript restrict that. Thoughts?