### PR TITLE
Ale 253 load note from database

### DIFF
--- a/app/notes/note.tsx
+++ b/app/notes/note.tsx
@@ -1,38 +1,66 @@
+import { eq } from 'drizzle-orm'
+import { redirect } from 'react-router'
 import type { Route } from './+types/note'
 import { requireAuthenticatedUser } from '~/lib/require-authenticated-user.server'
 import { Note } from '~/features/note/note'
+import { notes } from '~/database/schema'
 
 export async function loader({ context, request }: Route.LoaderArgs) {
-  await requireAuthenticatedUser({
+  const { userId } = await requireAuthenticatedUser({
     request,
     sessionStorage: context.sessionStorage,
   })
 
-  return null
+  const note = await context.db.query.notes.findFirst({
+    where: eq(notes.authorId, userId),
+    columns: {
+      id: true,
+      title: true,
+      content: true,
+      updatedAt: true,
+    },
+    with: {
+      notesToTags: {
+        columns: {},
+        with: {
+          tag: {
+            columns: {
+              id: true,
+              name: true,
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!note) {
+    throw redirect('/notes')
+  }
+
+  const formattedNote = {
+    title: note.title,
+    content: note.content,
+    tags: note.notesToTags.map((noteToTag) => noteToTag.tag.name),
+    lastEdited: new Date(note.updatedAt).toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      year: 'numeric',
+    }),
+  }
+
+  return { note: formattedNote }
 }
 
-export default function NoteRoute() {
+export default function NoteRoute({ loaderData }: Route.ComponentProps) {
+  const { note } = loaderData
+
   return (
     <Note
-      title="React Performance Optimization"
-      tags={['Dev', 'React']}
-      lastEdited="29 Oct 2024"
-      content={`Key performance optimization techniques:
-        
-1. Code Splitting
-- Use React.lazy() for route-based splitting
-- Implement dynamic imports for heavy components
-
-2.	Memoization
-- useMemo for expensive calculations
-- useCallback for function props
-- React.memo for component optimization
-
-3. Virtual List Implementation
-- Use react-window for long lists
-- Implement infinite scrolling
-
-TODO: Benchmark current application and identify bottlenecks`}
+      title={note.title}
+      tags={note.tags}
+      lastEdited={note.lastEdited}
+      content={note.content}
     />
   )
 }

--- a/database/schema.ts
+++ b/database/schema.ts
@@ -1,3 +1,4 @@
+import { relations, sql } from 'drizzle-orm'
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 export const guestBook = sqliteTable('guestBook', {
@@ -11,3 +12,59 @@ export const users = sqliteTable('users', {
   email: text().notNull().unique(),
   passwordHash: text().notNull(),
 })
+
+export const usersRelations = relations(users, ({ many }) => ({
+  notes: many(notes),
+}))
+
+export const notes = sqliteTable('notes', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  title: text().notNull(),
+  content: text().notNull(),
+  authorId: integer()
+    .references(() => users.id)
+    .notNull(),
+  createdAt: text()
+    .default(sql`(CURRENT_TIMESTAMP)`)
+    .notNull(),
+  updatedAt: text()
+    .default(sql`(CURRENT_TIMESTAMP)`)
+    .notNull(),
+})
+
+export const notesRelations = relations(notes, ({ one, many }) => ({
+  author: one(users, {
+    fields: [notes.authorId],
+    references: [users.id],
+  }),
+  notesToTags: many(notesToTags),
+}))
+
+export const tags = sqliteTable('tags', {
+  id: integer().primaryKey({ autoIncrement: true }),
+  name: text().notNull().unique(),
+})
+
+export const tagsRelations = relations(tags, ({ many }) => ({
+  notesToTags: many(notesToTags),
+}))
+
+export const notesToTags = sqliteTable('notesToTags', {
+  noteId: integer()
+    .references(() => notes.id)
+    .notNull(),
+  tagId: integer()
+    .references(() => tags.id)
+    .notNull(),
+})
+
+export const notesToTagsRelations = relations(notesToTags, ({ one }) => ({
+  note: one(notes, {
+    fields: [notesToTags.noteId],
+    references: [notes.id],
+  }),
+  tag: one(tags, {
+    fields: [notesToTags.tagId],
+    references: [tags.id],
+  }),
+}))

--- a/drizzle/0002_dashing_satana.sql
+++ b/drizzle/0002_dashing_satana.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `notes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`title` text NOT NULL,
+	`content` text NOT NULL,
+	`authorId` integer NOT NULL,
+	`createdAt` text DEFAULT (CURRENT_TIMESTAMP),
+	`updatedAt` text DEFAULT (CURRENT_TIMESTAMP),
+	FOREIGN KEY (`authorId`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `notesToTags` (
+	`noteId` integer NOT NULL,
+	`tagId` integer NOT NULL,
+	FOREIGN KEY (`noteId`) REFERENCES `notes`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`tagId`) REFERENCES `tags`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE TABLE `tags` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `tags_name_unique` ON `tags` (`name`);

--- a/drizzle/0003_nice_silvermane.sql
+++ b/drizzle/0003_nice_silvermane.sql
@@ -1,0 +1,15 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_notes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`title` text NOT NULL,
+	`content` text NOT NULL,
+	`authorId` integer NOT NULL,
+	`createdAt` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+	`updatedAt` text DEFAULT (CURRENT_TIMESTAMP) NOT NULL,
+	FOREIGN KEY (`authorId`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_notes`("id", "title", "content", "authorId", "createdAt", "updatedAt") SELECT "id", "title", "content", "authorId", "createdAt", "updatedAt" FROM `notes`;--> statement-breakpoint
+DROP TABLE `notes`;--> statement-breakpoint
+ALTER TABLE `__new_notes` RENAME TO `notes`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,247 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c9769d9f-3fe8-43c9-bf1e-e448b5968c12",
+  "prevId": "3f081506-675c-4b28-83e5-5aca0c49721f",
+  "tables": {
+    "guestBook": {
+      "name": "guestBook",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guestBook_email_unique": {
+          "name": "guestBook_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_authorId_users_id_fk": {
+          "name": "notes_authorId_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notesToTags": {
+      "name": "notesToTags",
+      "columns": {
+        "noteId": {
+          "name": "noteId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notesToTags_noteId_notes_id_fk": {
+          "name": "notesToTags_noteId_notes_id_fk",
+          "tableFrom": "notesToTags",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "noteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notesToTags_tagId_tags_id_fk": {
+          "name": "notesToTags_tagId_tags_id_fk",
+          "tableFrom": "notesToTags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,247 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "80ce4e19-9f00-4e5e-9f66-55949e8a4451",
+  "prevId": "c9769d9f-3fe8-43c9-bf1e-e448b5968c12",
+  "tables": {
+    "guestBook": {
+      "name": "guestBook",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "guestBook_email_unique": {
+          "name": "guestBook_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notes": {
+      "name": "notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "authorId": {
+          "name": "authorId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(CURRENT_TIMESTAMP)"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notes_authorId_users_id_fk": {
+          "name": "notes_authorId_users_id_fk",
+          "tableFrom": "notes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "authorId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notesToTags": {
+      "name": "notesToTags",
+      "columns": {
+        "noteId": {
+          "name": "noteId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tagId": {
+          "name": "tagId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "notesToTags_noteId_notes_id_fk": {
+          "name": "notesToTags_noteId_notes_id_fk",
+          "tableFrom": "notesToTags",
+          "tableTo": "notes",
+          "columnsFrom": [
+            "noteId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "notesToTags_tagId_tags_id_fk": {
+          "name": "notesToTags_tagId_tags_id_fk",
+          "tableFrom": "notesToTags",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tagId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "passwordHash": {
+          "name": "passwordHash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,20 @@
       "when": 1753727260030,
       "tag": "0001_known_shape",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1754472691926,
+      "tag": "0002_dashing_satana",
+      "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1754490896289,
+      "tag": "0003_nice_silvermane",
+      "breakpoints": true
     }
   ]
 }

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,95 +1,87 @@
 import { expect, test } from '../playwright-utilities'
 
-test.describe('unauthenticated user', () => {
-  test.use({ authStatus: 'unauthenticated' })
+test('homepage redirects to login if not authenticated', async ({ page }) => {
+  await page.goto('/')
 
-  test('homepage redirects to login if not authenticated', async ({ page }) => {
-    // TODO explicitly don't have a session cookie (right now we just don't have one by default)
-    await page.goto('/')
-
-    await expect(
-      page.getByRole('heading', { name: 'Welcome to Note' }),
-    ).toBeVisible()
-    await expect(page.getByRole('button', { name: 'Login' })).toBeVisible()
-    await expect(page.url()).toContain('/login')
-  })
-
-  test('signup with unused email', async ({ page, makeUser, signupPage }) => {
-    const user = makeUser()
-
-    await signupPage.goto()
-    await signupPage.signup(user)
-
-    await expect(
-      page.getByRole('heading', { name: 'Welcome to the Home Page' }),
-    ).toBeVisible()
-  })
-
-  test('attempt signup with used email', async ({
-    page,
-    signupUser,
-    signupPage,
-  }) => {
-    const user = await signupUser()
-
-    await signupPage.goto()
-    await signupPage.signup(user)
-
-    await expect(page.getByText('Email is already used')).toBeVisible()
-  })
-
-  test('login with valid credentials', async ({
-    page,
-    signupUser,
-    loginPage,
-  }) => {
-    const user = await signupUser()
-
-    await loginPage.goto()
-
-    await loginPage.login(user)
-
-    await expect(
-      page.getByRole('heading', { name: 'Welcome to the Home Page' }),
-    ).toBeVisible()
-  })
-
-  test('login with incorrect password', async ({
-    page,
-    signupUser,
-    loginPage,
-  }) => {
-    const user = await signupUser()
-
-    await loginPage.goto()
-
-    await loginPage.login({ ...user, password: 'incorrect' })
-
-    await expect(page.getByText('Invalid email or password')).toBeVisible()
-  })
-
-  test('login with incorrect email', async ({
-    page,
-    signupUser,
-    loginPage,
-  }) => {
-    const user = await signupUser()
-
-    await loginPage.goto()
-    await loginPage.login({ ...user, email: 'incorrect@example.com' })
-
-    await expect(page.getByText('Invalid email or password')).toBeVisible()
-  })
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to Note' }),
+  ).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Login' })).toBeVisible()
+  await expect(page.url()).toContain('/login')
 })
 
-test.describe('authenticated user', () => {
-  test.use({ authStatus: 'authenticated' })
+test('signup with unused email', async ({ page, makeUser, signupPage }) => {
+  const user = makeUser()
 
-  test('homepage shows welcome message', async ({ page }) => {
-    await page.goto('/')
+  await signupPage.goto()
+  await signupPage.signup(user)
 
-    await expect(
-      page.getByRole('heading', { name: 'Welcome to the Home Page' }),
-    ).toBeVisible()
-  })
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to the Home Page' }),
+  ).toBeVisible()
+})
+
+test('attempt signup with used email', async ({
+  page,
+  signupUser,
+  signupPage,
+}) => {
+  const user = await signupUser()
+
+  await signupPage.goto()
+  await signupPage.signup(user)
+
+  await expect(page.getByText('Email is already used')).toBeVisible()
+})
+
+test('login with valid credentials', async ({
+  page,
+  signupUser,
+  loginPage,
+}) => {
+  const user = await signupUser()
+
+  await loginPage.goto()
+
+  await loginPage.login(user)
+
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to the Home Page' }),
+  ).toBeVisible()
+})
+
+test('login with incorrect password', async ({
+  page,
+  signupUser,
+  loginPage,
+}) => {
+  const user = await signupUser()
+
+  await loginPage.goto()
+
+  await loginPage.login({ ...user, password: 'incorrect' })
+
+  await expect(page.getByText('Invalid email or password')).toBeVisible()
+})
+
+test('login with incorrect email', async ({ page, signupUser, loginPage }) => {
+  const user = await signupUser()
+
+  await loginPage.goto()
+  await loginPage.login({ ...user, email: 'incorrect@example.com' })
+
+  await expect(page.getByText('Invalid email or password')).toBeVisible()
+})
+
+test('homepage shows welcome message if authenticated', async ({
+  page,
+  loginUser,
+}) => {
+  await loginUser()
+
+  await page.goto('/')
+
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to the Home Page' }),
+  ).toBeVisible()
 })

--- a/tests/e2e/note.spec.ts
+++ b/tests/e2e/note.spec.ts
@@ -2,9 +2,8 @@ import { inArray } from 'drizzle-orm'
 import { expect, test } from '../playwright-utilities'
 import { notes, notesToTags, tags } from '~/database/schema'
 
-test.use({ authStatus: 'unauthenticated' })
-test('shows a note', async ({ page, signupUser, loginPage, db }) => {
-  const user = await signupUser()
+test('shows a note', async ({ page, loginUser, db }) => {
+  const user = await loginUser()
   const note = {
     title: 'Test Note',
     tags: ['test-tag', 'test-2-tag'],
@@ -46,12 +45,6 @@ test('shows a note', async ({ page, signupUser, loginPage, db }) => {
     throw new Error('Note not saved')
   }
 
-  await loginPage.goto()
-  await loginPage.login(user)
-
-  await expect(
-    page.getByRole('heading', { name: 'Welcome to the Home Page' }),
-  ).toBeVisible()
   await page.goto(`/notes/${savedNote.id}`)
 
   await expect(page.getByText(note.title)).toBeVisible()

--- a/tests/e2e/note.spec.ts
+++ b/tests/e2e/note.spec.ts
@@ -1,0 +1,62 @@
+import { inArray } from 'drizzle-orm'
+import { expect, test } from '../playwright-utilities'
+import { notes, notesToTags, tags } from '~/database/schema'
+
+test.use({ authStatus: 'unauthenticated' })
+test('shows a note', async ({ page, signupUser, loginPage, db }) => {
+  const user = await signupUser()
+  const note = {
+    title: 'Test Note',
+    tags: ['test-tag', 'test-2-tag'],
+    content: 'This is a note',
+  }
+
+  const tagsThatAlreadyExist = await db.query.tags.findMany({
+    where: inArray(tags.name, note.tags),
+  })
+  const newTags = note.tags.filter(
+    (tag) => !tagsThatAlreadyExist.some((t) => t.name === tag),
+  )
+
+  if (newTags.length > 0) {
+    await db
+      .insert(tags)
+      .values(newTags.map((tag) => ({ name: tag })))
+      .returning()
+  }
+  const savedTags = await db.query.tags.findMany({
+    where: inArray(tags.name, note.tags),
+  })
+
+  const savedNotes = await db
+    .insert(notes)
+    .values({ title: note.title, content: note.content, authorId: user.id })
+    .returning({ id: notes.id })
+  for (const savedNote of savedNotes) {
+    for (const savedTag of savedTags) {
+      await db
+        .insert(notesToTags)
+        .values({ noteId: savedNote.id, tagId: savedTag.id })
+        .returning()
+    }
+  }
+
+  const savedNote = savedNotes[0]
+  if (!savedNote) {
+    throw new Error('Note not saved')
+  }
+
+  await loginPage.goto()
+  await loginPage.login(user)
+
+  await expect(
+    page.getByRole('heading', { name: 'Welcome to the Home Page' }),
+  ).toBeVisible()
+  await page.goto(`/notes/${savedNote.id}`)
+
+  await expect(page.getByText(note.title)).toBeVisible()
+  await expect(page.getByText(note.content)).toBeVisible()
+  for (const tag of note.tags) {
+    await expect(page.getByText(tag)).toBeVisible()
+  }
+})


### PR DESCRIPTION
Sets up the database schema for a note. Renders real note data rather than a placeholder in the UI. Adds an end to end test to check that we can get that data properly. Updates the test fixtures to explicitly include a `loginUser` fixture that returns a user that you can use, rather than the very basic authStatus